### PR TITLE
Fix the contact_remindr pivot table

### DIFF
--- a/src/main/java/com/sweetjandy/remindr/models/Contact.java
+++ b/src/main/java/com/sweetjandy/remindr/models/Contact.java
@@ -41,7 +41,12 @@ public class Contact {
 //    private long secretCode;
 
 
-    @ManyToMany(cascade = ALL, mappedBy = "contacts")
+    @ManyToMany(cascade = ALL)
+    @JoinTable(
+    name = "contact_remindr",
+    joinColumns = {@JoinColumn(name = "contact_id")},
+    inverseJoinColumns = {@JoinColumn(name = "remindr_id")}
+    )
     private List<Remindr> remindrs;
 
     public Contact() {

--- a/src/main/java/com/sweetjandy/remindr/models/Remindr.java
+++ b/src/main/java/com/sweetjandy/remindr/models/Remindr.java
@@ -58,11 +58,7 @@ public class Remindr {
     @JsonManagedReference
     private User user;
 
-    @ManyToMany(cascade = CascadeType.ALL)@JoinTable(
-            name = "contact_remindr",
-            joinColumns = {@JoinColumn(name = "contact_id")},
-            inverseJoinColumns = {@JoinColumn(name = "remindr_id")}
-    )
+    @ManyToMany(mappedBy = "remindrs")
     private List<Contact> contacts;
 
 


### PR DESCRIPTION
-Have the remindr table contain the mappedBy attribute making the contact table the owner of the relationship (the remindr table will be ignored when updating the relationship values in the pivot table).

-Formulate the foreign key columns using the @JoinTable annotation in the Contact model.