### PR TITLE
Contact crud functionality fix

### DIFF
--- a/src/main/java/com/sweetjandy/remindr/controllers/ContactsController.java
+++ b/src/main/java/com/sweetjandy/remindr/controllers/ContactsController.java
@@ -182,6 +182,7 @@ public class ContactsController {
 
 //        returns amount of contacts that are duplicated by phone number
         long duplicates = user.getContacts().stream().filter(c -> c.getPhoneNumber().equals(contact.getPhoneNumber())).count();
+//        Contact sameContact = contactsRepository.findOne(contact.getId() =
 
         if (duplicates > 0) {
             validation.rejectValue(

--- a/src/main/java/com/sweetjandy/remindr/controllers/ContactsController.java
+++ b/src/main/java/com/sweetjandy/remindr/controllers/ContactsController.java
@@ -205,6 +205,7 @@ public class ContactsController {
             viewModel.addAttribute("contact", contact);
             return "users/edit-contact";
         }
+        contact.setUser(user);
         contactsRepository.save(contact);
 
         return "redirect:/contacts";

--- a/src/main/java/com/sweetjandy/remindr/models/Contact.java
+++ b/src/main/java/com/sweetjandy/remindr/models/Contact.java
@@ -139,4 +139,8 @@ public class Contact {
     public void setUser(User user) {
         this.user = user;
     }
+
+    public boolean stillHasSameNumber(Contact myself) {
+        return phoneNumber.equals(myself.phoneNumber);
+    }
 }

--- a/src/main/resources/templates/fragments/deleteContactModal.html
+++ b/src/main/resources/templates/fragments/deleteContactModal.html
@@ -7,16 +7,16 @@
 
 <div th:fragment="deleteContactModalScript">
     <script th:inline="javascript">
-    function confirmDeleteContact() {
-        var contactId=[[${contact.id}]];
-        $.ajax({
-            url: '/contacts/' + contactId + '/delete',
-            type: 'POST',
-            success: function(result) {
-                location.href="/contacts";
-            },
-            error: function(result){}
-        });	}
+        function confirmDeleteContact() {
+            var contactId=[[${contact.id}]];
+            $.ajax({
+                url: '/contacts/' + contactId + '/delete',
+                type: 'POST',
+                success: function(result) {
+                    location.href="/contacts";
+                },
+                error: function(result){}
+            });	}
     </script>
 </div>
 </body>

--- a/src/main/resources/templates/fragments/deleteContactModal.html
+++ b/src/main/resources/templates/fragments/deleteContactModal.html
@@ -4,20 +4,36 @@
 </head>
 <body>
 
-
 <div th:fragment="deleteContactModalScript">
-    <script th:inline="javascript">
+	<script th:inline="javascript">
         function confirmDeleteContact() {
             var contactId=[[${contact.id}]];
+
+            //set variable equal to the content inside specified meta tag containing token information.
+            var token = $("meta[name='_csrf']").attr("content");
+            console.log('Contact Id is: ' + contactId);
+            console.log('CSRF Token is: ' + $('#csrf').val());
+
+            //Before ajax request happens, sets X-CSRF-TOKEN value (which the browser uses for session), equal to the token variable.
+            $.ajaxSetup({
+                beforeSend: function(xhr) {
+                    xhr.setRequestHeader('X-CSRF-TOKEN', token);
+                }
+            });
+
             $.ajax({
                 url: '/contacts/' + contactId + '/delete',
                 type: 'POST',
                 success: function(result) {
                     location.href="/contacts";
+                    console.log('location.href: ' + location.href);
                 },
-                error: function(result){}
+                error: function(result){
+                    console.log('data: ' + data);
+                    console.log(result);
+                }
             });	}
-    </script>
+	</script>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/partials.html
+++ b/src/main/resources/templates/fragments/partials.html
@@ -3,6 +3,10 @@
 	  xmlns:sec="http://www.thymeleaf.org/thymeleaf-extras-springsecurity4" lang="en">
 <head th:fragment="head(title)">
     <meta charset="UTF-8" />
+
+	<!--token information is inserted into meta tag-->
+	<meta name="_csrf" th:content="${_csrf.token}"/>
+	<meta name="_csrf_header" th:content="${_csrf.headerName}"/>
     <title th:text="${title}"></title>
     <!-- include stylesheets, etc here -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous" />

--- a/src/main/resources/templates/users/view-contact.html
+++ b/src/main/resources/templates/users/view-contact.html
@@ -26,6 +26,8 @@
 
 </div>
 
+<input type="hidden" id="csrf" name="${_csrf.parameterName}"   value="${_csrf.token}"/>
+
 <div class="modal fade" tabindex="-1" role="dialog" id="deleteContactModal">
 	<div class="modal-dialog" role="document">
 		<div class="modal-content">


### PR DESCRIPTION
-Edit Functionality: set a user to the contact being edited, so after editing a contact the user_id won't become null in the database.

-Delete Functionality: Retain the token created from when a user signs in, so the user can delete a contact.

-Allow the user to update a contact's first name or last name  without having to change the contact's phoneNumber.